### PR TITLE
Fix input tensor format

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,10 +16,11 @@ tf.loadFrozenModel(MODEL_URL, WEIGHTS_URL).then((model) => {
 
   async function executeModel(url) {
     const resource = await loadImage(url);
-    const image = tf.fromPixels(resource);
+    const image = tf.fromPixels(resource).toFloat();
+    // Model input pixels should be floats in (0,1) range instead of integers (0,255)
+    const normalized = image.div(255);
 
-    let tensor = tf.zeros([1, IMAGE_SIZE, IMAGE_SIZE, 3]);
-    tensor[0] = image;
+    const tensor = normalized.reshape([1, IMAGE_SIZE, IMAGE_SIZE, 3]);
 
     // const prediction = model.predict({ Placeholder: tensor }) // MobileNet V2
     const prediction = model.predict(tensor); // MobileNet V1


### PR DESCRIPTION
Changes:
1/ Model input pixels should be floats in (0,1) range instead of integers (0,255)
2/ For some reason assigning the image as tensor[0] is not creating the right input shape.  There is a simpler API that apparently works `image.reshape([1, IMAGE_SIZE, IMAGE_SIZE, 3]);`

Fixes #1 